### PR TITLE
feature/#CU-c4pu6t-Update-the-docs

### DIFF
--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -141,7 +141,7 @@ paths:
                                         type: array
                                         example: ['Invalid agency/agent entered']
 
-    /book/trip/{trip_id}:
+    /book/trip/{trip_id}/?agency={agency}:
         get:
             parameters:
                 - in: path
@@ -150,6 +150,14 @@ paths:
                       type: string
                   description: A unique key used for identification and when booking a trip.
                   example: "129a4045ef84edc4c0d5f0b1b28a906495d3f966"
+                - in: query
+                  name: agency
+                  schema:
+                      type: string
+                  description: >
+                    Travel agency for which to list bookings from. Either this or agent_email should be passed.
+                    This parameter is incompatible with `agent_email`.
+                  example: tripninja
             summary: "Booking Detail"
             description: "Retrieve a booking details"
             operationId: "BookingDetail"


### PR DESCRIPTION
**DESCRIPTION**
In order to properly determine users access rights to the trip details we need to check whether the username is the same as the username on the trip, whether the user is the agent admin of the trip or whether the user is a super user. This prevents unwanted users accessing trips that they shouldn't have access to. 

**CHANGES**
- Updated the url for booking by trip id

