### PR TITLE
Feature/#cu-f0thzu-add-markup-by-itinerary

### DIFF
--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -624,6 +624,10 @@ components:
                         $ref: '#/components/schemas/credentials'
                     itinerary_type:
                         $ref: '#/components/schemas/segment_type'
+                    itinerary_markup:
+                      type: number
+                      description: Markup for the itinerary. Trip markup and Itinerary markup parameters are mutualy exclusive
+                      example: 7
                     segments:
                         type: array
                         description: The segments chosen for the trip
@@ -780,6 +784,10 @@ components:
                           $ref: '#/components/schemas/credentials'
                       itinerary_type:
                           $ref: '#/components/schemas/segment_type'
+                      itinerary_markup:
+                        type: number
+                        description: Markup for the itinerary. Trip markup and Itinerary markup parameters are mutualy exclusive
+                        example: 7
                       segments:
                           type: array
                           description: The segments chosen for the trip

--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -626,6 +626,7 @@ components:
                         $ref: '#/components/schemas/segment_type'
                     itinerary_markup:
                       type: number
+                      default: 0
                       description: Markup for the itinerary. Trip markup and Itinerary markup parameters are mutualy exclusive
                       example: 7
                     segments:
@@ -786,6 +787,7 @@ components:
                           $ref: '#/components/schemas/segment_type'
                       itinerary_markup:
                         type: number
+                        default: 0
                         description: Markup for the itinerary. Trip markup and Itinerary markup parameters are mutualy exclusive
                         example: 7
                       segments:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -555,6 +555,10 @@ components:
             type: string
             description: Links part of the OPEN_JAW itineraries/VI-structures together which also make a PNR.
             example: ad76ah7dhasd76asb76
+          itinerary_markup:
+            type: number
+            description: Markup for the itinerary. Trip markup and Itinerary markup parameters are mutualy exclusive
+            example: 7
           itinerary_structure:
             type: string
             description: Structure of the OPEN_JAW itinerary

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -557,6 +557,7 @@ components:
             example: ad76ah7dhasd76asb76
           itinerary_markup:
             type: number
+            default: 0
             description: Markup for the itinerary. Trip markup and Itinerary markup parameters are mutualy exclusive
             example: 7
           itinerary_structure:


### PR DESCRIPTION
added markup parameter to search, and booking details response. And price request and response
default if 0

Search/ response:
![image](https://user-images.githubusercontent.com/22523866/97516076-93efa900-194f-11eb-9187-0b9622428763.png)

Price/
![image](https://user-images.githubusercontent.com/22523866/97516149-bda8d000-194f-11eb-87dd-731edf902a83.png)
![image](https://user-images.githubusercontent.com/22523866/97516163-c6010b00-194f-11eb-9f7a-625e560b568b.png)

Booking Detail
![image](https://user-images.githubusercontent.com/22523866/97516304-14aea500-1950-11eb-9921-24b48bec4ef9.png)

