### PR TITLE
feature/#CU-errmg5-Return-VI-segmentPNR-price-separately

### DIFF
--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -785,6 +785,18 @@ components:
                           description: The segments chosen for the trip
                           items:
                               $ref: '#/components/schemas/segment_response'
+                      base_fare:
+                          type: float
+                          description: base fare for this itinerary of the pricing response.
+                          example: 115.50
+                      taxes:
+                          type: float
+                          description: The taxes assocaited with this itinerary of the pricing response.
+                          example: 34.55
+                      fees:
+                          type: float
+                          description: The feess associated with this itinerary in the pricing response.
+                          example: 12.99
     brand:
       type: array
       description: An array of brands relating to each flight of the segment

--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -787,15 +787,15 @@ components:
                               $ref: '#/components/schemas/segment_response'
                       base_fare:
                           type: float
-                          description: base fare for this itinerary of the pricing response.
+                          description: The confirmed base fare for this itinerary of the pricing response.
                           example: 115.50
                       taxes:
                           type: float
-                          description: The taxes assocaited with this itinerary of the pricing response.
+                          description: The confirmed taxes associated with this itinerary of the pricing response.
                           example: 34.55
                       fees:
                           type: float
-                          description: The feess associated with this itinerary in the pricing response.
+                          description: The confirmed feess associated with this itinerary in the pricing response.
                           example: 12.99
     brand:
       type: array

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -573,6 +573,21 @@ components:
             description: ID mapping VI parts of the option together. Helps finding VI solutions located in same segment position.
             example: fc906f39e5151f1bc5ef788b85f3d280770b5b7c__b9ebd56ff7bf07a65a3e4dc70e9551e4ae50f1da
             nullable: true
+          vi_segment_base_price:
+            type: float
+            description: The base price of the VI PNR not including taxes and fees.
+            example: 106.40
+            nullable: true
+          vi_segment_taxes:
+            type: float
+            description: The taxes associated with this VI PNR.
+            example: 24.12
+            nullable: true
+          vi_segment_fees:
+            type: float
+            description: The fees associated with this individual VI PNR.
+            example: 14.56
+            nullable: true
           itinerary_index:
             type: int
             description: |


### PR DESCRIPTION
**DESCRIPTION**
There are some changes to the search response and the pricing response in order to get pricing by itinerary. 
See the ticket here for some details:
https://app.clickup.com/t/errmg5
See the related PR on MCFS here:
https://github.com/trip-ninja-inc/trip_ninja_api/pull/1116

**CHANGES**
Search response:
![image](https://user-images.githubusercontent.com/27984048/97583515-cba13400-19d5-11eb-89e6-594f5f87320d.png)

Price response: 
![image](https://user-images.githubusercontent.com/27984048/97583590-e1aef480-19d5-11eb-9f10-d6ad8fd0ff56.png)
