### PR TITLE
feature/CU-vf6w6r-Add-docs-for-hotel-rules

### DIFF
--- a/tn_api_hotel.yml
+++ b/tn_api_hotel.yml
@@ -1010,7 +1010,6 @@ components:
           required:
             - pcc
             - provider
-            - pcc_currency
             - data_source
           properties:
             pcc:
@@ -1021,10 +1020,6 @@ components:
               description: Fare provider to use.<br  />“1V” - Apollo, “1G” - Galileo, “1P” - Worldspan, “1A” - Amadeus
               type: string
               example: 1V
-            pcc_currency:
-              description: The currency that is associated with the PCC. This will be the currency that any bookings are made and charged in.
-              type: string
-              example: CAD
             data_source:
               description: The datasource that is associated with the PCC.
               type: string

--- a/tn_api_hotel.yml
+++ b/tn_api_hotel.yml
@@ -267,6 +267,79 @@ paths:
                 500:
                     description: Server Error
 
+    /rules/hotels/{endpoint}/:
+      post:
+        parameters:
+          - in: path
+            name: endpoint
+            required: true
+            schema:
+              type: string
+              enum: [ preprod, prod ]
+              description: Parameter toggles data source production and pre-production endpoints.
+        summary: "Hotel Rules"
+        description: Get the rules details of the selected hotel_code, hotel_chain, and rate_plan_type. This is a required operation prior to booking as elements of this are saved in the cache and reused in booking.
+        operationId: Rules
+        requestBody:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HotelRulesRequest'
+        responses:
+          200:
+            description: Success
+            content:
+              application/json:
+                schema:
+                  $ref: '#/components/schemas/HotelRulesResponse'
+          400:
+            description: Invalid Input
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    status:
+                      type: string
+                      description: Error code and 0 for success response
+                      example: IE23
+                    message:
+                      type: string
+                      description: Contains the error message
+                      example: Not a valid rate_plan_type.
+          401:
+            description: Unauthorized
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    status:
+                      type: string
+                      description: Error code and 0 for success response
+                      example: IE44
+                    message:
+                      type: string
+                      description: Contains the error message
+                      example: "User is not authorized"
+          206:
+            description: Partial Content (no Hotel found)
+            content:
+              application/json:
+                schema:
+                  type: object
+                  properties:
+                    status:
+                      type: string
+                      description: Error code and 0 for success response
+                      example: IE23
+                    message:
+                      type: string
+                      description: Contains the error message
+                      example: "No availability found: Try changing dates"
+          500:
+            description: Server Error
+
 
     /price/hotels/{endpoint}/:
       post:
@@ -803,6 +876,8 @@ components:
             example: 705.10
             description: Cost of all hotel prices combined.
 
+
+
     HotelMediaRequest:
         required:
           - hotels
@@ -862,4 +937,137 @@ components:
                                         type: string
                                         description: The url for the image of the above titled part of the hotel of size thumbnail.
                                         example: https://media-cdn.tripadvisor.com/media/photo-m/1280/1b/45/0b/f8/lobby.jpg
+
+
+
+    HotelRulesRequest:
+      required:
+        - hotel_itinerary_reference
+        - hotel_trace_id
+        - hotel_chain
+        - hotel_code
+        - rate_plan_type
+        - base_price_incl_curr
+        - traveller_total
+        - rooms_total
+        - check_in_date
+        - check_out_date
+        - credential_info
+      properties:
+        hotel_itinerary_reference:
+          type: string
+          example: '1'
+          description: A reference that indicates the itineraries position in the flow of itineraries in the super_trip with the index starting at 0.
+        hotel_trace_id:
+          type: string
+          example: 'ndsf6sjf6sdf7sdf6'
+          description: An identifier to refer to the hotel for searching room availability
+        hotel_chain:
+          type: string
+          description: The refence for the hotel chain.
+          example: 'GI'
+        hotel_code:
+          type: string
+          description: The reference for the hotel code
+          example: '35573'
+        rate_plan_type:
+          type: string
+          description: The reference for the room and rate plan selection
+          example: 'A01LV8'
+        base_price_incl_curr:
+          type: string
+          description: The total price of the room including the currency, as returned from hotel details
+          example: 'USD1234.56'
+        traveller_total:
+          type: int
+          example: 3
+          description: Number of people that will be staying at the hotel.
+        rooms_total:
+          type: int
+          example: 2
+          description: The number of rooms required for the above travellers.
+        check_in_date:
+          type: string
+          format: date
+          description: "Date of check-in. format: YYYY-MM-DD."
+        check_out_date:
+          type: string
+          format: date
+          description: "Date to checkout from the hotel. format: YYYY-MM-DD."
+        credential_info:
+          type: object
+          required:
+            - pcc
+            - provider
+            - pcc_currency
+            - data_source
+          properties:
+            pcc:
+              description: PCC/OfficeID to emulate transactions under. Must have emulation enabled for the relevant Service Bureau PCC used by Trip Ninja to conduct queries.
+              type: string
+              example: 2G3C
+            provider:
+              description: Fare provider to use.<br  />“1V” - Apollo, “1G” - Galileo, “1P” - Worldspan, “1A” - Amadeus
+              type: string
+              example: 1V
+            pcc_currency:
+              description: The currency that is associated with the PCC. This will be the currency that any bookings are made and charged in.
+              type: string
+              example: CAD
+            data_source:
+              description: The datasource that is associated with the PCC.
+              type: string
+              enum: [travelport, travelport_student, travelport_itx, amadeus, tripstack, mystifly]
+
+
+    HotelRulesResponse:
+      properties:
+        hotel_trace_id:
+          type: string
+          example: 'ndsf6sjf6sdf7sdf6'
+          description: An identifier to refer to the hotel for searching room availability
+        super_trip_id:
+          type: string
+          example: "bdf876sf6sfsdf87sdf"
+          description: id of the super trip.
+        cancellation_policy_text:
+          type: string
+          description: The cancellation policy
+          example: 'non-refundable rate cancellation permitted up to 1days before arrival'
+        guarantee_policy_text:
+          type: string
+          description: The guarantee policy
+          example: ''
+        deposit:
+          type: string
+          description: The deposit requirements
+          example: 'book 7 days before arrival full room , tax payment due 174.40 gbp deposit due -at time of booking credit card deposit only'
+        room_rate_descriptions:
+          type: array
+          description: A list of the various rate description information - includes types such as Extra Charges, Rate comment, Rate description, Room detail, Room rate, Room text
+          items:
+            type: object
+            properties:
+              description_type:
+                type: string
+                description: The type of description
+                example: 'Extra charges'
+              description_text:
+                type: string
+                description: The full text of the description
+                example: 'rollaway - 10.00 gbp per room per night'
+        rule_descriptions:
+          type: array
+          description: A list of the various rate rules - includes types such as Cancellation, Deposit, Location Text, Miscellaneous, Promotional, and PropertyText
+          items:
+            type: object
+            properties:
+              description_type:
+                type: string
+                description: The type of rule description
+                example: 'Cancellation'
+              description_text:
+                type: string
+                description: The full text of the ruledescription
+                example: 'non-refundable rate cancellation permitted up to 1days before arrival'
 


### PR DESCRIPTION
Clickup: https://app.clickup.com/t/vf6w6r

Changes:
1. Added hotel rules req/rsp docs

Testing:
1. Check the docs - `npx redoc-cli serve tn_api_hotel.yml`
Compare with the following files:
- hotels/hotel_rules/object_model/hotel_rules_request.py 
- hotels/hotel_rules/object_model/hotel_rules_response.py 
- hotels/hotel_rules/tests/hotel_rules_tests.py <- or whatever it's called in the newest file structure