### PR TITLE
ENG-293 - updated base url for the html files so that its pointing to the right domain

### DIFF
--- a/hotel.html
+++ b/hotel.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://docs.tripninja.io/tn_api_hotel.yml' hide-download-button></redoc>
+    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_hotel.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://docs.tripninja.io/tn_api_spec.yml' hide-download-button></redoc>
+    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_spec.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/pricing_and_booking.html
+++ b/pricing_and_booking.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://docs.tripninja.io/tn_api_pricing_booking_spec.yml' hide-download-button></redoc>
+    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_pricing_booking_spec.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/v2.html
+++ b/v2.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://docs.tripninja.io/tn_api_v2.yml' hide-download-button></redoc>
+    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_v2.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>


### PR DESCRIPTION
Currently the https://api-documentation.tripninja.io/ is not loading the docs because its still pointing to the old docs.tripninja.io, this pr is for updating the sub-domain name so that its pointing to the right url.

No localQA is needed