### PR TITLE
ENG-273 - Updated API docs accordingly with the changes made on ENG-273 in the MCFS repo

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -437,7 +437,7 @@ paths:
                                     properties:
                                         status:
                                             type: string
-                                            example: "ticketed"
+                                            example: "success"
                     400:
                         description: Invalid Input
                         content:
@@ -1882,6 +1882,10 @@ components:
                 items:
                     type: string
                     example: [ "18fd1992fd90e6e2cf44d49308a1482b2ecd7f67", "59e15240be759a023c950e66379dca775fd8aaf1"]
+            queue:
+                type: string
+                description: Length of the queue number has to be within 3 letters.
+                example: "001"
 
     CancelRequest:
         title: Request


### PR DESCRIPTION
## Description
Updated the api docs for /ticketing/, now showing `queue` property in the docs

Ticket: https://app.clickup.com/t/14197839/ENG-273


## How to test
1. Checkout this branch
2. Run `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080/#operation/TicketingReport
4. You shall see `queue` is now a property in the request body