### PR TITLE
updated include_itineraries and mix_structures

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1570,10 +1570,10 @@ components:
                 type: string
           include_itineraries:
               description: Enables itineraries to be constructed and returned from segments found for the requested trip.
-              default: true
+              default: false
               type: boolean
           mix_structures:
-              description: Return mix of results with the best multi-pnr structure and single-pnr structure. include_itineraries needs to be passed as True for this to work
+              description: Return mix of results with the best multi-pnr structure and single-pnr structure.
               default: false
               type: boolean
           multi_pnr_mix:


### PR DESCRIPTION
## LocalQA approved by
@sunny-trip-ninja 

## Description

Updated the docs for include_itineraries and mix_structures to reflect current behaviour.

Ticket: https://app.clickup.com/t/14197839/ENG-307

## How to Test

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://localhost:8080/#operation/Search
4. Inspect include_itineraries, the default should now be false
5. Inspect mix_structures, their should **NOT** be instructions that it must be used only with include_itineraries set as true.
