### PR TITLE
Update num_results from 250 to 1000.

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -62,7 +62,7 @@ info:
       <tr><td>IE23</td><td>Not a valid alliance. Expected one of *A, *S, *O</td></tr>
       <tr><td>IE24</td><td>Travellers Type does not meet expected criteria. Should be a list having between 0 and 10 values</td></tr>
       <tr><td>IE26</td><td>Exclude_carriers, alliance and permitted_carriers are mutually exclusive - please choose one</td></tr>
-      <tr><td>IE27</td><td>Num_results should be an integer between 50 and 250</td></tr>
+      <tr><td>IE27</td><td>Num_results should be an integer between 50 and 1000</td></tr>
       <tr><td>IE28</td><td>Refundable parameter must be boolean value true or false</td></tr>
       <tr><td>IE29</td><td>Invalid Traveller type</td></tr>
       <tr><td>IE30</td><td>Incorrect value for single_pnr, must be boolean</td></tr>
@@ -912,7 +912,7 @@ components:
                             description: exclude_carriers, alliance and permitted_carriers are mutually exclusive - please choose one
                         IE27:
                             type: string
-                            description: num_results should be an integer between 50 and 250
+                            description: num_results should be an integer between 50 and 1000
                         IE28:
                             type: string
                             description: refundable parameter must be a boolean value true or false
@@ -1559,7 +1559,7 @@ components:
               default: 50
               type: integer
               minimum: 50
-              maximum: 250
+              maximum: 1000
           include_lcc:
               description: Enable a hybrid search of both GDS and low cost carrier content. This requires prior setup with Trip Ninja and an agreement with an LCC provider.
               default: []
@@ -1745,7 +1745,7 @@ components:
                 default: 50
                 type: integer
                 minimum: 50
-                maximum: 250
+                maximum: 1000
 
     FlexTripSearchResponse:
       title: Response

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1576,6 +1576,10 @@ components:
               description: Return mix of results with the best multi-pnr structure and single-pnr structure.
               default: false
               type: boolean
+          single_pnr:
+            description: Return single-pnr structures in addition to the results returned. If there are too many results, it will be truncated to num_results.
+            default: false
+            type: boolean
           multi_pnr_mix:
               description: Return mix of single-pnr and all multi-pnr structures. include_itineraries and mix_structures needs to be passed as True for this to work
               default: false


### PR DESCRIPTION
## LocalQA approved by
@Sanpele 
@sunny-trip-ninja 

## Description

Updated the docs for num_results to reflect new upper bound for results allowed.
Added single_pnr to API documentation.

Ticket: https://app.clickup.com/t/14197839/ENG-330

## How to Test

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. Inspect num_results, make sure that it says 50 to 1000 instead of 50 to 250 in any place that references it.
5. Make sure single_pnr has a field and description added for it in the documentation.