### PR TITLE
Updated flight_details and leg_details for SUPP-228 and to update to our current response 

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -766,7 +766,7 @@ components:
             description: "Arrival date and time with timezone."
             example: "2020-12-06T09:10:00+00:00"
           flight_number:
-            type: int
+            type: integer
             description: Flight number.
             example: 530
           carrier:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -740,10 +740,6 @@ components:
       items:
         type: object
         properties:
-          reference:
-            type: integer
-            description: reference to flight in segment_options>flights.
-            example: 1
           origin:
             type: string
             description: IATA code of the segment origin
@@ -770,7 +766,7 @@ components:
             description: "Arrival date and time with timezone."
             example: "2020-12-06T09:10:00+00:00"
           flight_number:
-            type: integer
+            type: string
             description: Flight number.
             example: 530
           carrier:
@@ -779,16 +775,106 @@ components:
             maxLength: 2
             description: "Airline carrier of the flight."
             example: "AC"
-          operating_carrier:
-            type: string
-            minLength: 2
-            maxLength: 2
-            description: "Operating airline of the flight."
-            example: "AC"
           flight_time:
             type: integer
             description: Flight duration in minutes
             example: 475
+          carrier_fullname:
+            type: string
+            description: Full name of the carrier
+            example: Air Canada
+          reference:
+            type: string
+            description: reference to flight in flight_details list.
+            example: 83810422f17f30a4c7a366af5a12d9d05c86c04d
+          aircraft_type:
+            type: string
+            description: IATA type code for aircraft model.
+            example: 7M8
+          fare_info_ref:
+            type: string
+            description: Flight identifer required to make a travelport fare rule request. *Travelport Only*
+            example: WPADWJK0nDKATShj2JAAAA==
+          fare_rule_key:
+            type: string
+            description: Key corresponding to above fare_info_ref also required to make a travelport fare rule request. *Travelport Only*
+            example: gws-eJxNT0EKAjEMfMwy96SNxd5auqig7GFZlO7B/z/DaVR00oQOMxnaUkqQEOQosfxjwnOqDa3OwILA7pcdJkkESrZACFwf6ba37QwPyZpc+pWiu5FWPxx9CAOf2e8rBYvpbVBMiFZjVfIRYWK+Dmd13jxpqJrzN/y08g2EJ4odeOUPXvRTL2E=
+
+    LegDetails:
+      title: Leg Details
+      type: array
+      description: A list of legs for this segment
+      items:
+        type: object
+        properties:
+          OriginName:
+            type: string
+            description: Full name of the flight origin
+            example: "London, United Kingdom (LHR)"
+          Origin:
+              type: string
+              description: IATA code of the leg origin
+              example: LHR
+          DestinationName:
+              type: string
+              description: Full name of the leg destination
+              example: "Paris, France (CDG)"
+          Destination:
+              type: string
+              description: IATA code of the leg destination
+              example: CDG
+          DepartureTime:
+              type: string
+              description: Departure time of the leg
+              example: "2019-04-05T13:25:00.000+01:00"
+          ArrivalTime:
+              type: string
+              description: Arrival time of the leg
+              example: "2019-04-05T15:40:00.000+02:00"
+          FlightNumber:
+              type: string
+              description: Leg's flight number
+              example: 111
+          Carrier:
+              type: string
+              description: Leg's carrier code
+              example: BA
+          OperatingCarrier:
+              type: string
+              description: Leg's operating carrier code
+              example: WS    
+          FlightTime:
+              type: integer
+              description: Flight duration in minutes
+              example: 75
+          AircraftType:
+            type: string
+            description: IATA type code for aircraft model.
+            example: 7M8
+          Key:
+              type: string
+              description: Leg’s string identifier
+              example: "oHzo6pBAAA/B1d6hPLAAAA=="
+          BookingCode:
+              type: string
+              description: The airline booking code that describes the flight cabin class
+              example: X
+          cabin_class:
+              type: string
+              description: Leg’s cabin class *Travelport customers only*
+              example: Economy
+          fare_info_ref:
+            type: string
+            description: Flight identifer required to make a travelport fare rule request. *Travelport Only*
+            example: WPADWJK0nDKATShj2JAAAA==
+          fare_rule_key:
+            type: string
+            description: Key corresponding to above fare_info_ref also required to make a travelport fare rule request. *Travelport Only*
+            example: gws-eJxNT0EKAjEMfMwy96SNxd5auqig7GFZlO7B/z/DaVR00oQOMxnaUkqQEOQosfxjwnOqDa3OwILA7pcdJkkESrZACFwf6ba37QwPyZpc+pWiu5FWPxx9CAOf2e8rBYvpbVBMiFZjVfIRYWK+Dmd13jxpqJrzN/y08g2EJ4odeOUPXvRTL2E=
+          fare_type:
+              type: string
+              description: Leg's fare type 
+              example: PublicFare
 
 
 
@@ -1108,8 +1194,7 @@ components:
             description: “open_jaw” or “one_way”
             example: "open_jaw"
           legs:
-            type: array
-            description: A list of legs, each leg includes origin, destination, flight number, departure time and arrival time. Contains same objects as leg_details below.
+            $ref: '#/components/schemas/LegDetails'
           baggage:
             type: object
             description: Contains baggage information.
@@ -1224,57 +1309,9 @@ components:
                                     description: segment travel time accounting for time between flights
                                     example: 75.0
                                 leg_details:
-                                    type: object
-                                    description: A list of legs, each leg includes origin, destination, flight number, departure time and arrival time
-                                    properties:
-                                        Origin:
-                                            type: string
-                                            description: IATA code of the leg origin
-                                            example: LHR
-                                        DepartureTime:
-                                            type: string
-                                            description: Departure time of the leg
-                                            example: "2019-04-05T13:25:00.000+01:00"
-                                        Destination:
-                                            type: string
-                                            description: IATA code of the leg destination
-                                            example: CDG
-                                        FlightNumber:
-                                            type: string
-                                            description: Leg's flight number
-                                            example: 111
-                                        DestinationName:
-                                            type: string
-                                            description: Full name of the leg destination
-                                            example: "Paris, France (CDG)"
-                                        BookingCode:
-                                            type: string
-                                            description: The airline booking code that describes the flight cabin class
-                                            example: X
-                                        cabin_class:
-                                            type: string
-                                            description: Leg’s cabin class *Travelport customers only*
-                                            example: Economy
-                                        Carrier:
-                                            type: string
-                                            description: Leg's carrier code
-                                            example: BA
-                                        Key:
-                                            type: string
-                                            description: Leg’s string identifier
-                                            example: "oHzo6pBAAA/B1d6hPLAAAA=="
-                                        ArrivalTime:
-                                            type: string
-                                            description: Arrival time of the leg
-                                            example: "2019-04-05T15:40:00.000+02:00"
-                                        OriginName:
-                                            type: string
-                                            description: Full name of the leg origin
-                                            example: "London, United Kingdom (LHR)"
-                                        FlightTime:
-                                            type: integer
-                                            description: Flight duration in minutes
-                                            example: 75
+                                  $ref: '#/components/schemas/LegDetails'
+
+                                    
                 Group1:
                     type: object
                     description: |
@@ -1301,57 +1338,8 @@ components:
                                     description: segment travel time accounting for time between flights
                                     example: 1730.0
                                 leg_details:
-                                    type: object
-                                    description: A list of legs, each leg includes origin, destination, flight number, departure time and arrival time
-                                    properties:
-                                        Origin:
-                                            type: string
-                                            description: IATA code of the leg origin
-                                            example: CDG
-                                        DepartureTime:
-                                            type: string
-                                            description: Departure time of the leg
-                                            example: "2019-04-07T13:15:00.000+02:00"
-                                        Destination:
-                                            type: string
-                                            description: IATA code of the leg destination
-                                            example: YUL
-                                        FlightNumber:
-                                            type: string
-                                            description: Leg's flight number
-                                            example: 475
-                                        DestinationName:
-                                            type: string
-                                            description: Full name of the leg destination
-                                            example: "Montreal, PQ, Canada (YUL)"
-                                        BookingCode:
-                                            type: string
-                                            description: The airline booking code that describes the flight cabin class
-                                            example: X
-                                        cabin_class:
-                                            type: string
-                                            description: Leg’s cabin class *Travelport customers only*
-                                            example: Economy
-                                        Carrier:
-                                            type: string
-                                            description: Leg's carrier code
-                                            example: TS
-                                        Key:
-                                            type: string
-                                            description: Leg’s string identifier
-                                            example: "oHzo6pBAAA/B1d6hPLAAAA=="
-                                        ArrivalTime:
-                                            type: string
-                                            description: Arrival time of the leg
-                                            example: "2019-04-07T15:10:00.000-04:00"
-                                        OriginName:
-                                            type: string
-                                            description: Full name of the leg origin
-                                            example: "Paris, France (CDG)"
-                                        FlightTime:
-                                            type: integer
-                                            description: Flight duration in minutes
-                                            example: 475
+                                    $ref: '#/components/schemas/LegDetails'
+
     CredentialInfo:
         type: object
         description: Indicate data source to call and required credentials

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -743,7 +743,7 @@ components:
           origin:
             type: string
             description: IATA code of the segment origin
-            example: LHR
+            example: "LHR"
           origin_name:
             type: string
             description: Full name of the flight origin
@@ -751,7 +751,7 @@ components:
           destination:
             type: string
             description: IATA code of the segment destination
-            example: CDG
+            example: "CDG"
           destination_name:
             type: string
             description: Full name of the flight destination
@@ -766,7 +766,7 @@ components:
             description: "Arrival date and time with timezone."
             example: "2020-12-06T09:10:00+00:00"
           flight_number:
-            type: string
+            type: int
             description: Flight number.
             example: 530
           carrier:
@@ -782,7 +782,7 @@ components:
           carrier_fullname:
             type: string
             description: Full name of the carrier
-            example: Air Canada
+            example: "Air Canada"
           operating_carrier:
             type: string
             minLength: 2
@@ -792,23 +792,23 @@ components:
           operating_carrier_fullname:
             type: string
             description: Full name of the operating carrier
-            example: Westjet
+            example: "Westjet"
           reference:
             type: string
             description: reference to flight in flight_details list.
-            example: 83810422f17f30a4c7a366af5a12d9d05c86c04d
+            example: "83810422f17f30a4c7a366af5a12d9d05c86c04d"
           aircraft_type:
             type: string
             description: IATA type code for aircraft model.
-            example: 7M8
+            example: "7M8"
           fare_info_ref:
             type: string
             description: Flight identifer required to make a travelport fare rule request. *Travelport Only*
-            example: WPADWJK0nDKATShj2JAAAA==
+            example: "WPADWJK0nDKATShj2JAAAA=="
           fare_rule_key:
             type: string
             description: Key corresponding to above fare_info_ref also required to make a travelport fare rule request. *Travelport Only*
-            example: gws-eJxNT0EKAjEMfMwy96SNxd5auqig7GFZlO7B/z/DaVR00oQOMxnaUkqQEOQosfxjwnOqDa3OwILA7pcdJkkESrZACFwf6ba37QwPyZpc+pWiu5FWPxx9CAOf2e8rBYvpbVBMiFZjVfIRYWK+Dmd13jxpqJrzN/y08g2EJ4odeOUPXvRTL2E=
+            example: "gws-eJxNT0EKAjEMfMwy96SNxd5auqig7GFZlO7B/z/DaVR00oQOMxnaUkqQEOQosfxjwnOqDa3OwILA7pcdJkkESrZACFwf6ba37QwPyZpc+pWiu5FWPxx9CAOf2e8rBYvpbVBMiFZjVfIRYWK+Dmd13jxpqJrzN/y08g2EJ4odeOUPXvRTL2E="
 
     LegDetails:
       title: Leg Details
@@ -824,7 +824,7 @@ components:
           Origin:
               type: string
               description: IATA code of the leg origin
-              example: LHR
+              example: "LHR"
           DestinationName:
               type: string
               description: Full name of the leg destination
@@ -832,7 +832,7 @@ components:
           Destination:
               type: string
               description: IATA code of the leg destination
-              example: CDG
+              example: "CDG"
           DepartureTime:
               type: string
               description: Departure time of the leg
@@ -848,11 +848,11 @@ components:
           Carrier:
               type: string
               description: Leg's carrier code
-              example: BA
+              example: "BA"
           OperatingCarrier:
               type: string
               description: Leg's operating carrier code
-              example: WS    
+              example: "WS"    
           FlightTime:
               type: integer
               description: Flight duration in minutes
@@ -860,7 +860,7 @@ components:
           AircraftType:
             type: string
             description: IATA type code for aircraft model.
-            example: 7M8
+            example: "7M8"
           Key:
               type: string
               description: Leg’s string identifier
@@ -868,23 +868,23 @@ components:
           BookingCode:
               type: string
               description: The airline booking code that describes the flight cabin class
-              example: X
+              example: "X"
           cabin_class:
               type: string
               description: Leg’s cabin class *Travelport customers only*
-              example: Economy
+              example: "Economy"
           fare_info_ref:
             type: string
             description: Flight identifer required to make a travelport fare rule request. *Travelport Only*
-            example: WPADWJK0nDKATShj2JAAAA==
+            example: "WPADWJK0nDKATShj2JAAAA=="
           fare_rule_key:
             type: string
             description: Key corresponding to above fare_info_ref also required to make a travelport fare rule request. *Travelport Only*
-            example: gws-eJxNT0EKAjEMfMwy96SNxd5auqig7GFZlO7B/z/DaVR00oQOMxnaUkqQEOQosfxjwnOqDa3OwILA7pcdJkkESrZACFwf6ba37QwPyZpc+pWiu5FWPxx9CAOf2e8rBYvpbVBMiFZjVfIRYWK+Dmd13jxpqJrzN/y08g2EJ4odeOUPXvRTL2E=
+            example: "gws-eJxNT0EKAjEMfMwy96SNxd5auqig7GFZlO7B/z/DaVR00oQOMxnaUkqQEOQosfxjwnOqDa3OwILA7pcdJkkESrZACFwf6ba37QwPyZpc+pWiu5FWPxx9CAOf2e8rBYvpbVBMiFZjVfIRYWK+Dmd13jxpqJrzN/y08g2EJ4odeOUPXvRTL2E="
           fare_type:
               type: string
               description: Leg's fare type 
-              example: PublicFare
+              example: "PublicFare"
 
 
 

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1051,6 +1051,8 @@ components:
                     $ref: '#/components/schemas/Itineraries'
                 segments:
                     $ref: '#/components/schemas/Segments'
+                flight_details:
+                    $ref: '#/components/schemas/FlightDetails'
 
     Itineraries:
         allOf:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -783,6 +783,16 @@ components:
             type: string
             description: Full name of the carrier
             example: Air Canada
+          operating_carrier:
+            type: string
+            minLength: 2
+            maxLength: 2
+            description: "Operating airline of the flight."
+            example: "WS"
+          operating_carrier_fullname:
+            type: string
+            description: Full name of the operating carrier
+            example: Westjet
           reference:
             type: string
             description: reference to flight in flight_details list.


### PR DESCRIPTION
## LocalQA approved by
@sunny-trip-ninja 

## Description

* updated FlightDetails fields for SUPP-228 a couple additional updates.
* moved leg_details into the LegDetails component and made similar field updates.
* added LegDetails component to the BasicSegmentInfo.

TIcket : https://app.clickup.com/t/14197839/ENG-349

## How to Test

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. In the response sample on the left for search or fare_structure, 
![Screen Shot 2022-08-04 at 9 45 35 AM](https://user-images.githubusercontent.com/47077094/182876559-f5053566-129-4aa2-99cc-d5cd99e59511.png)
5. you should be able to step into the leg details by clicking itineraries -> segments -> legs. The Leg Details list should also now contain fare_info_ref and fare_rule_key.
6.  inspect the response below the response below FareStructure
![Screen Shot 2022-08-04 at 9 40 58 AM](https://user-images.githubusercontent.com/47077094/182875474-a02547a2-086b-4ad8-896a-e1fda2657d3b.png)
Click FareStructure -> segments -> group1 or group0 -> segment_details -> leg_details. This should be the same updated leg_details as in step 4.
7. If you now inspect the 200 response below search as below
![Screen Shot 2022-08-04 at 9 42 23 AM](https://user-images.githubusercontent.com/47077094/182875856-c3d82abb-50ae-4cc2-bbe6-fbc67d7309c6.png)
click on flight_details. in the flight details you should see fare_info_ref and fare_rule_key.

Thanks!!!