### PR TITLE
ENG-350 | updated return value for flight number

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -799,9 +799,9 @@ components:
             description: "Arrival date and time with timezone."
             example: "2020-12-06T09:10:00+00:00"
           flight_number:
-            type: integer
+            type: string
             description: Flight number.
-            example: 530
+            example: "530"
           carrier:
             type: string
             minLength: 2


### PR DESCRIPTION
## LocalQA approved by
@Sanpele 

## Description
- Updated flight_number to be a string type instead of an int type

TIcket : https://app.clickup.com/t/14197839/ENG-350

## How to Test

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. In the response sample on the left for **FareStructure**, **Search**, or **FlexTrip**
<img width="850" alt="image" src="https://user-images.githubusercontent.com/99681496/189430960-c0b491fe-8449-47f2-a212-515c3e2a969e.png">

5. you should be able to step into the flight_number by clicking `200 Success` > `FareStructure` -> `flight_details` -> `flight_number`
<img width="423" alt="image" src="https://user-images.githubusercontent.com/99681496/189431810-d3d5f5b6-90c3-42ac-bef1-1692dbde2508.png">

6. You should be able to see the flight number in the response samples located on the right side under the **200 responses** for `/fare-structure-prod/`, `/search/{endpoint}/`, `/flex-trip-prod/` under `flight_details` -> `flight_number`
<img width="551" alt="image" src="https://user-images.githubusercontent.com/99681496/189431667-6551b7e8-7b34-47b2-a942-60d9129b25e2.png">
