### PR TITLE
API doc v4.11.0 version update

### DIFF
--- a/tn_api_hotel.yml
+++ b/tn_api_hotel.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: 4.10.0
+  version: 4.11.0
   title: Trip Ninja API Documentation
   description: |
     <h2>Introduction</h2>

--- a/tn_api_hotel.yml
+++ b/tn_api_hotel.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: 4.9.0
+  version: 4.10.0
   title: Trip Ninja API Documentation
   description: |
     <h2>Introduction</h2>

--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "4.9.0"
+  version: "4.10.0"
   title: Trip Ninja Endpoint Documentation
   description: |
     <h2>Introduction</h2>

--- a/tn_api_pricing_booking_spec.yml
+++ b/tn_api_pricing_booking_spec.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "4.10.0"
+  version: "4.11.0"
   title: Trip Ninja Endpoint Documentation
   description: |
     <h2>Introduction</h2>

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "4.10.0"
+  version: "4.11.0"
   title: Trip Ninja API Documentation
   description: |
     <h2>Introduction</h2>

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1,7 +1,7 @@
 openapi: "3.0.0"
 
 info:
-  version: "4.9.0"
+  version: "4.10.0"
   title: Trip Ninja API Documentation
   description: |
     <h2>Introduction</h2>


### PR DESCRIPTION
## LocalQA approved by

## Description
- Updated flight, hotel and booking API doc version to 4.11.0

## How to Test

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. Look for the version-> it should now be 4.11.0
Compare with our docs at https://api-documentation.tripninja.io/

5. ctrl-c to quit this redoc preview.
6. run `npx @redocly/openapi-cli preview-docs tn_api_hotel.yml`
7. Go to http://127.0.0.1:8080
8. look for the version, it should now be 4.11.0
Compare with our docs at https://api-documentation.tripninja.io/hotel.html

9. ctrl-c to quit this redoc preview.
10. run `npx @redocly/openapi-cli preview-docs tn_api_pricing_booking_spec.yml`
11. Go to http://127.0.0.1:8080
12. look for the version, it should now be 4.11.0
Compare with our docs at https://api-documentation.tripninja.io/pricing_and_booking.html


