### PR TITLE
EPD-2827 | Update docs with region changes to flight search request

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1331,7 +1331,7 @@ components:
                 description: Parameter toggles which travelport regional service endpoint you hit *Travelport Only*
                 required: false
                 type: string
-                enum: ["emea","apac","americas","edge"]
+                enum: ["emea", "apac", "americas", "edge"]
                 default: "americas"
                 example: americas
             itx:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -64,7 +64,7 @@ info:
       <tr><td>IE10</td><td>Incorrect city_type, expected one of ['C', 'A']</td></tr>
       <tr><td>IE16</td><td>Please provide a PCC</td></tr>
       <tr><td>IE17</td><td>Invalid carrier</td></tr>
-      <tr><td>IE19</td><td>Incorrect region, expected one of 'emea', 'apac', 'americas','edge'</td></tr>
+      <tr><td>IE19</td><td>Incorrect region, expected one of 'emea', 'apac', 'americas', 'edge'</td></tr>
       <tr><td>IE20</td><td>Incorrect provider, expected one of '1V','1G','1P','1A'</td></tr>
       <tr><td>IE21</td><td>Wrong currency</td></tr>
       <tr><td>IE22</td><td>Not a valid cabin option. expected one of 'E' , 'PE', 'SE', 'BC','FC', 'PFC'</td></tr>
@@ -938,7 +938,7 @@ components:
                 description: Time Value (Original Alpha) outside of expected range [$0,$200]/hr
             IE19:
                 type: string
-                description: Incorrect region - expected one of ‘emea’,’apac’,’americas’,’edge’
+                description: Incorrect region - expected one of ‘emea’, ’apac’, ’americas’, ’edge’
             IE20:
                 type: string
                 description: Incorrect provider - expected one of '1V','1G','1P','1A'

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -64,7 +64,7 @@ info:
       <tr><td>IE10</td><td>Incorrect city_type, expected one of ['C', 'A']</td></tr>
       <tr><td>IE16</td><td>Please provide a PCC</td></tr>
       <tr><td>IE17</td><td>Invalid carrier</td></tr>
-      <tr><td>IE19</td><td>Incorrect region, expected one of 'emea', 'apac', 'americas'</td></tr>
+      <tr><td>IE19</td><td>Incorrect region, expected one of 'emea', 'apac', 'americas','edge'</td></tr>
       <tr><td>IE20</td><td>Incorrect provider, expected one of '1V','1G','1P','1A'</td></tr>
       <tr><td>IE21</td><td>Wrong currency</td></tr>
       <tr><td>IE22</td><td>Not a valid cabin option. expected one of 'E' , 'PE', 'SE', 'BC','FC', 'PFC'</td></tr>
@@ -832,7 +832,6 @@ components:
             num_results: 50
             cabin_class: E
             exclude_carriers: []
-            region: "americas"
             refundable: false
             currency: USD
             time_value: 0
@@ -939,7 +938,7 @@ components:
                 description: Time Value (Original Alpha) outside of expected range [$0,$200]/hr
             IE19:
                 type: string
-                description: Incorrect region - expected one of ‘emea’,’apac’,’americas’
+                description: Incorrect region - expected one of ‘emea’,’apac’,’americas’,’edge’
             IE20:
                 type: string
                 description: Incorrect provider - expected one of '1V','1G','1P','1A'
@@ -1332,6 +1331,8 @@ components:
                 description: Parameter toggles which travelport regional service endpoint you hit *Travelport Only*
                 required: false
                 type: string
+                enum: ["emea","apac","americas","edge"]
+                default: "americas"
                 example: americas
             itx:
                 description: toggles if this is an itx search
@@ -1505,11 +1506,6 @@ components:
               description: Parameter toggles query to only return fully refundable flights. *Travelport Only*
               default: false
               type: boolean
-          region:
-              description: Parameter toggles which travelport endpoint you hit *Travelport Only*
-              default: "americas"
-              type: string
-              enum: ["emea","apac","americas"]
           num_results:
               description: Parameter sets the number of segments in the response *Travelport Only*
               default: 50


### PR DESCRIPTION
localQA: @jashanjeet 

Changes:
- Removed the region param from the root of the search request - the region field in the credentials object is the one used and having two region params was causing confusion and issues.
- Added 'edge' option for regions

