### PR TITLE
EPD-3077 |  update api docs for vi=true include_itineraries = true

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1180,6 +1180,61 @@ components:
             type: string
             description: Fare Info reference for this segment
             example: 3RxQ6ylJ0BKAhQAbnbAAAA==
+          virtual_interline:
+            type: boolean
+            description: |
+              true if option is a vi solution
+            example: true
+          vi_solution_id:
+            type: string
+            description: |
+            ID mapping VI parts of the option together. Helps finding VI solutions located in same segment position. 
+            Will be composed of each segment's segment_id joined together with two underscores. For oneway VI this 
+            will be two segments, for openjaw VI will be 4 segments. 
+            example: fc906f39e5151f1bc5ef788b85f3d280770b5b7c__b9ebd56ff7bf07a65a3e4dc70e9551e4ae50f1da
+            nullable: true
+          itinerary_index:
+            type: int
+            description: |
+              position of the virtual interlining option in itinerary(PNR). Starts from 0
+              Helps ordering parts of the VI solution in relation to the itinerary as a whole
+            example: 0
+            nullable: true
+          vi_position:
+            type: integer
+            description: |
+              position of the virtual interlining option in the VI itinerary. Starts from 0. For OneWay VI will be either of [0, 1]. 
+              For OpenJaw VI will be one of [0, 1, 2, 3]
+            example: 1
+            nullable: true
+          itinerary_structure:
+            type:  Array of ints and/or Array of arrays
+            description: |
+              "Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
+              For example: [[0, 1], [3, 4], 2] means there would be three segments. One openjaw with key “01”, 
+              one with key “34” and a one-way with key ‘2”."
+              See Price Confirm Report segment_ids field for more detail.
+            example: [[0, 1], 2]
+          vi_pattern:
+            type: String
+            description: "OpenJaw VI only: String Array representing the structue of the OpenJaw VI solution that was found."
+            example: [[0, 3], 1, 2]
+          vi_segment_base_price:
+            type: float
+            description: The base price of the VI PNR not including taxes and fees.
+            example: 106.40
+            nullable: true
+          vi_segment_taxes:
+            type: float
+            description: The taxes associated with this VI PNR.
+            example: 24.12
+            nullable: true
+          vi_segment_fees:
+            type: float
+            description: The fees associated with this individual VI PNR.
+            example: 14.56
+            nullable: true
+
 
     Segments:
         allOf:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1188,9 +1188,9 @@ components:
           vi_solution_id:
             type: string
             description: |
-            ID mapping VI parts of the option together. Helps finding VI solutions located in same segment position. 
-            Will be composed of each segment's segment_id joined together with two underscores. For oneway VI this 
-            will be two segments, for openjaw VI will be 4 segments. 
+              ID mapping VI parts of the option together. Helps finding VI solutions located in same segment position. 
+              Will be composed of each segment's segment_id joined together with two underscores. For oneway VI this 
+              will be two segments, for openjaw VI will be 4 segments. 
             example: fc906f39e5151f1bc5ef788b85f3d280770b5b7c__b9ebd56ff7bf07a65a3e4dc70e9551e4ae50f1da
             nullable: true
           itinerary_index:
@@ -1208,17 +1208,17 @@ components:
             example: 1
             nullable: true
           itinerary_structure:
-            type:  Array of ints and/or Array of arrays
+            type:  String
             description: |
-              "Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
+              "String Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
               For example: [[0, 1], [3, 4], 2] means there would be three segments. One openjaw with key “01”, 
               one with key “34” and a one-way with key ‘2”."
               See Price Confirm Report segment_ids field for more detail.
-            example: [[0, 1], 2]
+            example: "[[0, 1], 2]"
           vi_pattern:
             type: String
             description: "OpenJaw VI only: String Array representing the structue of the OpenJaw VI solution that was found."
-            example: [[0, 3], 1, 2]
+            example: "[[0, 3], 1, 2]"
           vi_segment_base_price:
             type: float
             description: The base price of the VI PNR not including taxes and fees.
@@ -1581,8 +1581,10 @@ components:
               type: boolean
           should_compress_itinerary:
               description: | 
-                Return only a segment_id, source, price, weight for a segment inside an Itineraries object. A segment_details list will now be returned with the full segment details, the segment_id should be used to map a segment to the full details. Only works with include_itineraries also passed as true. Significantly reduces response size.
-                **Currenly being phased out, we are testing a new compression approach that is more effective**
+                Return only a segment_id, segment_source, price, weight for a segment inside an Itineraries object. A segment_details list will now be returned with the full segment details, 
+                the segment_id should be used to map a segment to the full details. Only works with include_itineraries also passed as true. Significantly reduces response size.
+                If virtual_interlining is passed as true, only segment_id, segment_souce and price are returned. Additionally for successfully virtually_interlined options a 
+                vi_position field is returned. This is the segments position in the virtually interlined itinerary. 
               default: false
               type: boolean
           mix_structures:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -1210,7 +1210,7 @@ components:
             description: |
               String Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
               For example: [[0, 1], [3, 4], 2] means there would be three segments. One openjaw with key “01”, 
-              one with key “34” and a one-way with key "2”.
+              one with key “34” and a one-way with key “2”.
               See Price Confirm Report segment_ids field for more detail.
             example: "[[0, 1], 2]"
           vi_pattern:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -489,7 +489,7 @@ components:
           itinerary_structure:
             type:  Array of ints and/or Array of arrays
             description: |
-              "Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
+              Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
               For example: [[0, 1], [3, 4], 2] means there would be three segments. One openjaw with key “01”, 
               one with key “34” and a one-way with key ‘2”."
               See Price Confirm Report segment_ids field for more detail.
@@ -527,7 +527,6 @@ components:
             type: int
             description: |
               Position of the virtual interlining option in itinerary(PNR). Starts from 0
-              Helps ordering parts of the VI solution in the itinerary
             example: 0
             nullable: true
           vi_position:
@@ -1197,7 +1196,6 @@ components:
             type: int
             description: |
               Position of the virtual interlining option in itinerary(PNR). Starts from 0
-              Helps ordering parts of the VI solution in relation to the itinerary as a whole
             example: 0
             nullable: true
           vi_position:
@@ -1210,9 +1208,9 @@ components:
           itinerary_structure:
             type:  String
             description: |
-              "String Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
+              String Array representing the structure of the trip in terms of one-ways and open-jaw segments. 
               For example: [[0, 1], [3, 4], 2] means there would be three segments. One openjaw with key “01”, 
-              one with key “34” and a one-way with key ‘2”."
+              one with key “34” and a one-way with key "2”.
               See Price Confirm Report segment_ids field for more detail.
             example: "[[0, 1], 2]"
           vi_pattern:

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -526,14 +526,14 @@ components:
           itinerary_index:
             type: int
             description: |
-              position of the virtual interlining option in itinerary(PNR). Starts from 0
+              Position of the virtual interlining option in itinerary(PNR). Starts from 0
               Helps ordering parts of the VI solution in the itinerary
             example: 0
             nullable: true
           vi_position:
             type: integer
             description: |
-              position of the virtual interlining option in itinerary. Starts from 0
+              Position of the virtual interlining option in itinerary. Starts from 0
             example: 1
             nullable: true
           weight:
@@ -1196,14 +1196,14 @@ components:
           itinerary_index:
             type: int
             description: |
-              position of the virtual interlining option in itinerary(PNR). Starts from 0
+              Position of the virtual interlining option in itinerary(PNR). Starts from 0
               Helps ordering parts of the VI solution in relation to the itinerary as a whole
             example: 0
             nullable: true
           vi_position:
             type: integer
             description: |
-              position of the virtual interlining option in the VI itinerary. Starts from 0. For OneWay VI will be either of [0, 1]. 
+              Position of the virtual interlining option in the VI itinerary. Starts from 0. For OneWay VI will be either of [0, 1]. 
               For OpenJaw VI will be one of [0, 1, 2, 3]
             example: 1
             nullable: true


### PR DESCRIPTION
## LocalQA approved by
@sunny-trip-ninja 

## Description
* Added VI specific fields to include_itineraries response segments
* Removed outdated msg i added back in the day

Ticket : https://app.clickup.com/t/860qkxve5

## How to Test

Critique the field descriptions, once satisfied: 

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. Go to the include_itineraries = true route_flexible = false response
5. Navigate down to the segments array you should find the following new fields with the new descriptions.
* vi_solution_id
* itinerary_index
* vi_position
* itinerary_structure
* vi_pattern
* vi_segment_base_price
* vi_segment_taxes
* vi_segment_fees 
6. repeat for the include_itineraries = true route_flexible = true response
7. Go the side bar to view the sample response.
8. Go to the include_itineraries = true route_flexible = false response
9. Navigate down to the segments array you should find the following new fields with the new descriptions.
* vi_solution_id
* itinerary_index
* vi_position
* itinerary_structure
* vi_pattern
* vi_segment_base_price
* vi_segment_taxes
* vi_segment_fees 
10. repeat for the include_itineraries = true route_flexible = true response

GtG!