### PR TITLE
update url to use github

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-trip-ninja-inc.github.io/trip_ninja_api_docs

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,1 @@
-api-documentation.tripninja.io
+trip-ninja-inc.github.io/trip_ninja_api_docs

--- a/core_v2.html
+++ b/core_v2.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_v2_core.yml' hide-download-button></redoc>
+    <redoc spec-url='https://trip-ninja-inc.github.io/trip_ninja_api_docs/tn_api_v2_core.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/hotel.html
+++ b/hotel.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_hotel.yml' hide-download-button></redoc>
+    <redoc spec-url='https://trip-ninja-inc.github.io/trip_ninja_api_docs/tn_api_hotel.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_spec.yml' hide-download-button></redoc>
+    <redoc spec-url='https://trip-ninja-inc.github.io/trip_ninja_api_docs/tn_api_spec.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/msdp.html
+++ b/msdp.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_msdp_v1.yml' hide-download-button></redoc>
+    <redoc spec-url='https://trip-ninja-inc.github.io/trip_ninja_api_docs/tn_api_msdp_v1.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/pricing_and_booking.html
+++ b/pricing_and_booking.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_pricing_booking_spec.yml' hide-download-button></redoc>
+    <redoc spec-url='https://trip-ninja-inc.github.io/trip_ninja_api_docs/tn_api_pricing_booking_spec.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>

--- a/v2.html
+++ b/v2.html
@@ -21,7 +21,7 @@
     </style>
 </head>
 <body>
-    <redoc spec-url='https://api-documentation.tripninja.io/tn_api_v2.yml' hide-download-button></redoc>
+    <redoc spec-url='https://trip-ninja-inc.github.io/trip_ninja_api_docs/tn_api_v2.yml' hide-download-button></redoc>
     <script src="https://cdn.jsdelivr.net/npm/redoc@next/bundles/redoc.standalone.js"> </script>
 </body>
 </html>


### PR DESCRIPTION
## LocalQA approved by

## Description
* Changed url's use url hosted on github

new URL will be : [trip-ninja-inc.github.io/trip_ninja_api_docs](http://trip-ninja-inc.github.io/trip_ninja_api_docs)

## How to Test
Won't be able to properly test on local. Therefore testing is more a verification that things look good and run properly. 

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. API should be present and running. 

GTG