### PR TITLE
EPD-4758 | Adding OTP fields

### DIFF
--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -529,8 +529,13 @@ components:
             example: true
           vi_solution_id:
             type: string
-            description: ID mapping VI parts of the option together. Helps finding VI solutions located in same segment position.
+            description: 
             example: fc906f39e5151f1bc5ef788b85f3d280770b5b7c__b9ebd56ff7bf07a65a3e4dc70e9551e4ae50f1da
+            nullable: true
+          risk_profile:
+            type: float
+            description: The probability of missing the connection and not performing the self-transfer during the VI self-connection (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: 8.42
             nullable: true
           vi_segment_base_price:
             type: float
@@ -789,6 +794,26 @@ components:
             type: number
             description: Arrival date and time in Unix timestamp form.
             example: 1687281000
+          cancellation_probability:
+            type: float
+            description: The probability percentage that this flight will be cancelled (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: 7.86
+            nullable: true
+          average_delay_time:
+            type: string
+            description: The average delay time of this flight in minutes. A negative value indicates an average early arrival time. (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: -5
+            nullable: true
+          self_transfer_time:
+            type: string
+            description: The self transfer time in minutes between this flights arrival time and the next segments departure time. (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: 134
+            nullable: true
+          is_international:
+            type: boolean
+            description: Indicates whether this flight is international. (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: true
+            nullable: true
 
     LegDetails:
       title: Leg Details
@@ -1287,6 +1312,31 @@ components:
               Will be composed of each segment's segment_id joined together with two underscores. For oneway VI this 
               will be two segments, for openjaw VI will be 4 segments. 
             example: fc906f39e5151f1bc5ef788b85f3d280770b5b7c__b9ebd56ff7bf07a65a3e4dc70e9551e4ae50f1da
+            nullable: true
+          risk_profile:
+            type: float
+            description: The probability of missing the connection and not performing the self-transfer during the VI self-connection (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: 8.42
+            nullable: true
+          cancellation_probability:
+            type: float
+            description: The probability percentage that this flight will be cancelled (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: 7.86
+            nullable: true
+          average_delay_time:
+            type: string
+            description: The average delay time of this flight in minutes. A negative value indicates an average early arrival time. (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: -5
+            nullable: true
+          self_transfer_time:
+            type: string
+            description: The self transfer time in minutes between this flights arrival time and the next segments departure time. (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: 134
+            nullable: true
+          is_international:
+            type: boolean
+            description: Indicates whether this flight is international. (only returned if you have our average delay time module enabled, and only for VI segments with a self transfer)
+            example: true
             nullable: true
           itinerary_index:
             type: int

--- a/tn_api_spec.yml
+++ b/tn_api_spec.yml
@@ -529,7 +529,7 @@ components:
             example: true
           vi_solution_id:
             type: string
-            description: 
+            description: ID mapping VI parts of the option together. Helps finding VI solutions located in same segment position.
             example: fc906f39e5151f1bc5ef788b85f3d280770b5b7c__b9ebd56ff7bf07a65a3e4dc70e9551e4ae50f1da
             nullable: true
           risk_profile:


### PR DESCRIPTION
## LocalQA approved by
@carson-ricca-tn 
## Description
* Added new OTP fields for include_itineraries: true and include_itineraries: false responses. 

The new fields are
* `risk_profile`
* `cancellation_probability`
* `average_delay_time`
* `self_transfer_time`
* `is_international`

Ticket : https://app.clickup.com/t/14197839/EPD-4758

## How to Test

1. Checkout this branch
2. Run  `npx @redocly/openapi-cli preview-docs tn_api_spec.yml`
3. Go to http://127.0.0.1:8080
4. The fields are in different locations depending on whether the example is selected for include_intineraries: true and include_itineraries: false. Start with include_itineraries false
![Screenshot 2023-10-13 at 4 08 33 PM](https://github.com/trip-ninja-inc/trip_ninja_api_docs/assets/47077094/309d6db2-414b-40de-a970-dbbe6cb64f87)
5. Open up `fare_structure ->  segments` and search for `risk_profile`. The field should be present and accounted for.
6. Now close segment and open the `flight_details` list.
7. Search for `cancellation_probability` The other 4 new fields should be present and accounted for.
8. Done with include_itineraries false. Now select one of the include_itineraries: true responses. 
9. Open `fare_structure -> itineraries -> segments` look for `risk_profile` field, all 5 of the new fields should be present!
10. Verify the descriptions make sense and are sensible.
11. Now go to the response samples in the right section and perform the same steps with the response samples. Verifying the fields are present in the right location for include_itineraries: true / false. 
